### PR TITLE
Update to Crystal 0.25.0

### DIFF
--- a/src/secrets.cr
+++ b/src/secrets.cr
@@ -46,10 +46,10 @@ module Secrets
         input << char
         print hint
       end
+      i += 1
     end
     puts
     input.join
-    i += 1
   end
 
   private def gets_char

--- a/src/secrets.cr
+++ b/src/secrets.cr
@@ -13,7 +13,8 @@ module Secrets
   def gets(prompt = "", hint = "*", empty_error : String? = nil, retry : Int32? = nil)
     print prompt
     input = [] of String
-    loop do |i|
+    i = 0
+    loop do
       char = gets_char
       case char[0].ord
       when 127
@@ -48,6 +49,7 @@ module Secrets
     end
     puts
     input.join
+    i += 1
   end
 
   private def gets_char


### PR DESCRIPTION
This PR fixes Crystal 0.25.0 compatibility

Fixes #1 

1. Fix `loop` argument, see: https://github.com/crystal-lang/crystal/pull/6026
